### PR TITLE
Add flatten-maven-plugin (fixes: issue #69)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.7</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <pomElements>
+                        <name/>
+                        <description/>
+                        <developers/>
+                        <url/>
+                        <scm/>
+                    </pomElements>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -205,13 +205,7 @@
                 <version>1.2.7</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
-                    <pomElements>
-                        <name/>
-                        <description/>
-                        <developers/>
-                        <url/>
-                        <scm/>
-                    </pomElements>
+                    <flattenMode>bom</flattenMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Solves the issue of "POM files without a version" caused by the usage of ${revision} property in a multi module project with Maven version below 3.5.
Issue described here:
https://blog.soebes.de/blog/2017/04/02/maven-pom-files-without-a-version-in-it/

Related StackOverFlow questions:
1. https://stackoverflow.com/questions/41086512/maven-issue-to-build-one-module-using-revision-property
2. https://stackoverflow.com/questions/52173260/how-to-resolve-parent-pom-dependency-issue-failed-to-read-artifact-descriptor/52173650#52173650