### PR TITLE
Add badges and fix GitHub build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build project
 on:
   push:
-    branches: /refs/heads/*
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,8 @@
 =  Auto configuration for Spring Data Aerospike
 
+image:https://img.shields.io/maven-central/v/com.aerospike/spring-data-aerospike-starters.svg?maxAge=259200["maven", link="https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-data-aerospike-starters%22"]
+image:https://github.com/aerospike-community/spring-data-aerospike-starters/workflows/Build%20project/badge.svg["build", link="https://github.com/aerospike-community/spring-data-aerospike-starters/actions?query=branch%3Amaster"]
+
 :repo-master: https://github.com/aerospike-community/spring-data-aerospike-starters/blob/master
 
 == Versions compatibility table


### PR DESCRIPTION
1. Add Maven Central and GitHub build action badges.
2. Fix GitHub build action push to master ("/refs/heads/*" doesn't work according to the build history - align with spring-data-aerospike build workflow.