### PR TITLE
Prepare version 0.8.0.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,11 @@ image:https://github.com/aerospike-community/spring-data-aerospike-starters/work
 |===
 |`spring-data-aerospike-starters` |`spring-data-aerospike` |`aerospike-client` |`aerospike-reactor-client`
 
+|0.8.x
+|3.5.x
+|6.1.x
+|6.1.x
+
 |0.7.x
 |3.4.x
 |5.1.x

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.6.6</version>
+        <version>2.7.5</version>
     </parent>
 
     <groupId>com.aerospike</groupId>
@@ -31,19 +31,20 @@
     </modules>
 
     <properties>
-        <revision>0.7.1</revision>
+        <revision>0.8.0</revision>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
+        <flatten.maven.plugin.version>1.3.0</flatten.maven.plugin.version>
 
-        <spring-data-aerospike.version>3.4.1</spring-data-aerospike.version>
-        <aerospike-reactor-client.version>5.1.11</aerospike-reactor-client.version>
-        <aerospike-client.version>5.1.11</aerospike-client.version>
+        <spring-data-aerospike.version>3.5.0</spring-data-aerospike.version>
+        <aerospike-reactor-client.version>6.1.2</aerospike-reactor-client.version>
+        <aerospike-client.version>6.1.3</aerospike-client.version>
 
-        <spring-cloud-starter.version>3.1.1</spring-cloud-starter.version>
+        <spring-cloud-starter.version>3.1.4</spring-cloud-starter.version>
     </properties>
 
     <licenses>
@@ -202,7 +203,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.2.7</version>
+                <version>${flatten.maven.plugin.version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>bom</flattenMode>

--- a/spring-boot-starter-data-aerospike-example/pom.xml
+++ b/spring-boot-starter-data-aerospike-example/pom.xml
@@ -16,7 +16,7 @@
     <description>Example for using Spring Boot Data Aerospike Starter</description>
 
     <properties>
-        <embedded-aerospike.version>2.1.5</embedded-aerospike.version>
+        <embedded-aerospike.version>2.2.10</embedded-aerospike.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
1. Bump dependencies:
spring-boot-dependencies from 2.6.6 to 2.7.5.
flatten-maven-plugin from 1.2.7 to 1.3.0.
spring-data-aerospike from 3.4.1 to 3.5.0.
aerospike-client from 5.1.11 to 6.1.3.
aerospike-reactor-client from 5.1.11 to 6.1.2.
spring-cloud-starter from 3.1.1 to 3.1.4.
embedded-aerospike from 2.1.5 to 2.2.10.

2. Set version to 0.8.0.
3. Update compatibility table.