### PR TITLE
Support Spring Boot 3 autoconfiguration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
 
       # See: https://github.com/actions/cache/blob/master/examples.md#java---maven
       - name: Maven cache and restore deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>0.8.1</revision>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.5</version>
+        <version>3.0.1</version>
     </parent>
 
     <groupId>com.aerospike</groupId>

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeAutoConfiguration.java
@@ -30,6 +30,7 @@ import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.reactor.AerospikeReactorClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -44,7 +45,7 @@ import reactor.core.publisher.Flux;
  *
  * @author Anastasiia Smirnova
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass(AerospikeClient.class)
 @ConditionalOnProperty("spring.aerospike.hosts")
 @EnableConfigurationProperties(AerospikeProperties.class)

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeCommonDataConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeCommonDataConfiguration.java
@@ -1,6 +1,7 @@
 package org.springframework.boot.autoconfigure.data.aerospike;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.domain.EntityScanner;
 import org.springframework.context.ApplicationContext;
@@ -23,7 +24,7 @@ import org.springframework.data.mapping.model.FieldNamingStrategy;
 
 import java.util.Collections;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 class AerospikeCommonDataConfiguration {
 
     @Bean(name = "aerospikeFilterExpressionsBuilder")

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.data.aerospike;
 
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.IAerospikeClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.aerospike.AerospikeAutoConfiguration;
@@ -36,7 +37,7 @@ import org.springframework.data.aerospike.repository.AerospikeRepository;
  * @author Igor Ermolenko
  * @author Anastasiia Smirnova
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 // match only if we do not have reactive client
 // we want sync context to be loaded when only sync client is on classpath
 @ConditionalOnMissingClass("com.aerospike.client.reactor.AerospikeReactorClient")

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.data.aerospike;
 
 import com.aerospike.client.IAerospikeClient;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,7 +43,7 @@ import org.springframework.data.aerospike.query.cache.InternalIndexOperations;
  * @author Igor Ermolenko
  * @author Anastasiia Smirnova
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 class AerospikeDataConfiguration {
 
     @Bean(name = "aerospikeTemplate")

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveDataAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.data.aerospike;
 
 import com.aerospike.client.reactor.AerospikeReactorClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.aerospike.AerospikeAutoConfiguration;
@@ -35,7 +36,7 @@ import reactor.core.publisher.Flux;
  * @author Igor Ermolenko
  * @author Anastasiia Smirnova
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass({AerospikeReactorClient.class, ReactiveAerospikeRepository.class, Flux.class})
 @ConditionalOnSingleCandidate(AerospikeReactorClient.class)
 @ConditionalOnProperty("spring.data.aerospike.namespace")

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveDataConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveDataConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.data.aerospike;
 
 import com.aerospike.client.reactor.AerospikeReactorClient;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,7 +43,7 @@ import org.springframework.data.aerospike.query.cache.ReactorIndexRefresher;
  * @author Igor Ermolenko
  * @author Anastasiia Smirnova
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 class AerospikeReactiveDataConfiguration {
 
     @Bean(name = "reactiveAerospikeTemplate")

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveRepositoriesAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.data.aerospike;
 
 import com.aerospike.client.reactor.AerospikeReactorClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,7 +34,7 @@ import reactor.core.publisher.Flux;
  *
  * @author Igor Ermolenko
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass({AerospikeReactorClient.class, ReactiveAerospikeRepository.class, Flux.class})
 @ConditionalOnRepositoryType(store = "aerospike", type = RepositoryType.REACTIVE)
 @ConditionalOnMissingBean(ReactiveAerospikeRepositoryFactoryBean.class)

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeRepositoriesAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.data.aerospike;
 
 import com.aerospike.client.AerospikeClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -32,7 +33,7 @@ import org.springframework.data.aerospike.repository.support.AerospikeRepository
  *
  * @author Igor Ermolenko
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass({AerospikeClient.class, ReactiveAerospikeRepository.class})
 @ConditionalOnRepositoryType(store = "aerospike", type = RepositoryType.IMPERATIVE)
 @ConditionalOnMissingBean(AerospikeRepositoryFactoryBean.class)

--- a/spring-boot-autoconfigure-data-aerospike/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,5 @@
+org.springframework.boot.autoconfigure.aerospike.AerospikeAutoConfiguration
+org.springframework.boot.autoconfigure.data.aerospike.AerospikeDataAutoConfiguration
+org.springframework.boot.autoconfigure.data.aerospike.AerospikeRepositoriesAutoConfiguration
+org.springframework.boot.autoconfigure.data.aerospike.AerospikeReactiveDataAutoConfiguration
+org.springframework.boot.autoconfigure.data.aerospike.AerospikeReactiveRepositoriesAutoConfiguration

--- a/spring-boot-autoconfigure-data-aerospike/src/test/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/test/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataAutoConfigurationTest.java
@@ -31,6 +31,7 @@ import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.core.AerospikeTemplate;
 import org.springframework.data.aerospike.core.ReactiveAerospikeTemplate;
 import org.springframework.data.aerospike.mapping.AerospikeMappingContext;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Set;
@@ -72,8 +73,7 @@ public class AerospikeDataAutoConfigurationTest {
                 .withUserConfiguration(EntityScanConfiguration.class, AerospikeClientMockConfiguration.class)
                 .run(context -> {
                     AerospikeMappingContext mappingContext = context.getBean(AerospikeMappingContext.class);
-                    Set<Class<?>> initialEntitySet = (Set<Class<?>>) ReflectionTestUtils.getField(mappingContext, "initialEntitySet");
-                    assertThat(initialEntitySet).containsOnly(City.class);
+                    assertThat(mappingContext.getManagedTypes()).containsOnly(TypeInformation.of(City.class));
                 });
     }
 

--- a/spring-boot-autoconfigure-data-aerospike/src/test/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveDataAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/test/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeReactiveDataAutoConfigurationTest.java
@@ -30,9 +30,7 @@ import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.core.AerospikeTemplate;
 import org.springframework.data.aerospike.core.ReactiveAerospikeTemplate;
 import org.springframework.data.aerospike.mapping.AerospikeMappingContext;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.Set;
+import org.springframework.data.util.TypeInformation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.autoconfigure.data.aerospike.TestUtils.getField;
@@ -69,8 +67,7 @@ public class AerospikeReactiveDataAutoConfigurationTest {
                 .withUserConfiguration(AerospikeTestConfigurations.EntityScanConfiguration.class, AerospikeClientMockConfiguration.class, MockReactiveIndexRefresher.class)
                 .run(context -> {
                     AerospikeMappingContext mappingContext = context.getBean(AerospikeMappingContext.class);
-                    Set<Class<?>> initialEntitySet = (Set<Class<?>>) ReflectionTestUtils.getField(mappingContext, "initialEntitySet");
-                    assertThat(initialEntitySet).containsOnly(City.class);
+                    assertThat(mappingContext.getManagedTypes()).containsOnly(TypeInformation.of(City.class));
                 });
     }
 

--- a/spring-boot-autoconfigure-data-aerospike/src/test/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeTestConfigurations.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/test/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeTestConfigurations.java
@@ -4,6 +4,7 @@ import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.cluster.Node;
 import com.aerospike.client.policy.InfoPolicy;
 import com.aerospike.client.policy.WritePolicy;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.data.aerospike.city.City;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 public class AerospikeTestConfigurations {
 
-    @Configuration(proxyBeanMethods = false)
+    @AutoConfiguration
     public static class AerospikeClientMockConfiguration {
 
         @Bean
@@ -34,7 +35,7 @@ public class AerospikeTestConfigurations {
 
     }
 
-    @Configuration(proxyBeanMethods = false)
+    @AutoConfiguration
     public static class MockReactiveIndexRefresher {
 
         @Bean
@@ -43,13 +44,13 @@ public class AerospikeTestConfigurations {
         }
     }
 
-    @Configuration(proxyBeanMethods = false)
+    @AutoConfiguration
     @EntityScan("org.springframework.boot.autoconfigure.data.aerospike.city")
     public static class EntityScanConfiguration {
 
     }
 
-    @Configuration(proxyBeanMethods = false)
+    @AutoConfiguration
     public static class CustomConversionsConfig {
 
         @Bean(name = "aerospikeCustomConversions")

--- a/spring-boot-starter-data-aerospike-example/reactive/src/test/java/com/aerospike/example/reactive/ReactiveIntegrationTest.java
+++ b/spring-boot-starter-data-aerospike-example/reactive/src/test/java/com/aerospike/example/reactive/ReactiveIntegrationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/spring-boot-starter-data-aerospike-example/sync/src/main/java/com/aerospike/example/sync/SyncCustomerRepository.java
+++ b/spring-boot-starter-data-aerospike-example/sync/src/main/java/com/aerospike/example/sync/SyncCustomerRepository.java
@@ -1,9 +1,10 @@
 package com.aerospike.example.sync;
 
 import org.springframework.data.aerospike.repository.AerospikeRepository;
+import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 
-public interface SyncCustomerRepository extends AerospikeRepository<Customer, String> {
+public interface SyncCustomerRepository extends AerospikeRepository<Customer, String>, CrudRepository<Customer, String> {
     List<Customer> findByLastNameOrderByFirstNameAsc(String lastName);
 }

--- a/spring-boot-starter-data-aerospike-example/sync/src/test/java/com/aerospike/example/sync/SyncIntegrationTest.java
+++ b/spring-boot-starter-data-aerospike-example/sync/src/test/java/com/aerospike/example/sync/SyncIntegrationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;


### PR DESCRIPTION
Since Spring Boot 3 autoconfigurations should be specified in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` instead of `spring.factories`.  https://docs.spring.io/spring-boot/docs/3.0.2-SNAPSHOT/reference/htmlsingle/#features.developing-auto-configuration.understanding-auto-configured-beans

This PR should add support for autoconfigurations with Spring Boot 3. Without this autoconfigurations are not detected by Spring.

Tried to run this with changes from https://github.com/aerospike-community/spring-data-aerospike-starters/pull/168, but there are some changes that affect tests.