### PR TITLE
FMWK-359 Deprecate AerospikeDataProperties

### DIFF
--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataProperties.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/data/aerospike/AerospikeDataProperties.java
@@ -19,13 +19,16 @@ package org.springframework.boot.autoconfigure.data.aerospike;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.aerospike.config.AerospikeDataSettings;
 
 /**
  * Configuration properties for Spring Data Aerospike.
+ * @deprecated since 0.14.0, {@link AerospikeDataSettings} will be used instead.
  *
  * @author Igor Ermolenko
  * @author Anastasiia Smirnova
  */
+@Deprecated(since = "0.14.0", forRemoval = true)
 @ConfigurationProperties(prefix = "spring.data.aerospike")
 @Getter
 @Setter


### PR DESCRIPTION
Deprecate AerospikeDataProperties class that duplicates configuration as application.properties is now supported natively by Spring Data Aerospike