### PR TITLE
Add ability to configure durableDelete property for Batch Client Policies

### DIFF
--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeAutoConfiguration.java
@@ -94,6 +94,9 @@ public class AerospikeAutoConfiguration {
         clientPolicy.writePolicyDefault = setupWritePolicy(properties);
         clientPolicy.batchPolicyDefault = setupBatchPolicy(properties);
         clientPolicy.queryPolicyDefault = setupQueryPolicy(properties);
+        clientPolicy.batchWritePolicyDefault = setupBatchWritePolicy(properties);
+        clientPolicy.batchDeletePolicyDefault = setupBatchDeletePolicy(properties);
+        clientPolicy.batchUDFPolicyDefault = setupBatchUDFPolicy(properties);
         aerospikeEventLoops.ifPresent(loops -> clientPolicy.eventLoops = loops);
 
         return clientPolicy;
@@ -139,6 +142,27 @@ public class AerospikeAutoConfiguration {
         whenPresent(batchPolicyDefault.maxConcurrentThreads, p -> policy.maxConcurrentThreads = p);
         whenPresent(batchPolicyDefault.allowInline, p -> policy.allowInline = p);
         whenPresent(batchPolicyDefault.sendSetName, p -> policy.sendSetName = p);
+        return policy;
+    }
+
+    private BatchWritePolicy setupBatchWritePolicy(AerospikeProperties properties) {
+        AerospikeProperties.BatchWritePolicyDefault batchWritePolicyDefault = properties.getBatchWrite();
+        BatchWritePolicy policy = new BatchWritePolicy();
+        whenPresent(batchWritePolicyDefault.durableDelete, p -> policy.durableDelete = p);
+        return policy;
+    }
+
+    private BatchDeletePolicy setupBatchDeletePolicy(AerospikeProperties properties) {
+        AerospikeProperties.BatchDeletePolicyDefault batchDeletePolicyDefault = properties.getBatchDelete();
+        BatchDeletePolicy policy = new BatchDeletePolicy();
+        whenPresent(batchDeletePolicyDefault.durableDelete, p -> policy.durableDelete = p);
+        return policy;
+    }
+
+    private BatchUDFPolicy setupBatchUDFPolicy(AerospikeProperties properties) {
+        AerospikeProperties.BatchUDFPolicyDefault batchUDFPolicyDefault = properties.getBatchUdf();
+        BatchUDFPolicy policy = new BatchUDFPolicy();
+        whenPresent(batchUDFPolicyDefault.durableDelete, p -> policy.durableDelete = p);
         return policy;
     }
 

--- a/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeProperties.java
+++ b/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeProperties.java
@@ -121,6 +121,12 @@ public class AerospikeProperties {
 
     private BatchPolicyDefault batch = new BatchPolicyDefault();
 
+    private BatchWritePolicyDefault batchWrite = new BatchWritePolicyDefault();
+
+    private BatchDeletePolicyDefault batchDelete = new BatchDeletePolicyDefault();
+
+    private BatchUDFPolicyDefault batchUdf = new BatchUDFPolicyDefault();
+
     private QueryPolicyDefault query = new QueryPolicyDefault();
 
     /**
@@ -231,5 +237,41 @@ public class AerospikeProperties {
          * Send set name for every key in the batch.
          */
         public Boolean sendSetName;
+    }
+
+    /**
+     * For more details on each option see corresponding field documentation in {@link com.aerospike.client.policy.BatchWritePolicy}.
+     */
+    @Data
+    public static class BatchWritePolicyDefault extends PolicyDefault {
+
+        /**
+         * If the transaction results in a record deletion, leave a tombstone for the record.
+         */
+        public Boolean durableDelete;
+    }
+
+    /**
+     * For more details on each option see corresponding field documentation in {@link com.aerospike.client.policy.BatchDeletePolicy}.
+     */
+    @Data
+    public static class BatchDeletePolicyDefault extends PolicyDefault {
+
+        /**
+         * If the transaction results in a record deletion, leave a tombstone for the record.
+         */
+        public Boolean durableDelete;
+    }
+
+    /**
+     * For more details on each option see corresponding field documentation in {@link com.aerospike.client.policy.BatchUDFPolicy}.
+     */
+    @Data
+    public static class BatchUDFPolicyDefault extends PolicyDefault {
+
+        /**
+         * If the transaction results in a record deletion, leave a tombstone for the record.
+         */
+        public Boolean durableDelete;
     }
 }


### PR DESCRIPTION
The same durableDelete property configuration as for WritePolicy:
https://github.com/aerospike-community/spring-data-aerospike-starters/blob/main/spring-boot-autoconfigure-data-aerospike/src/main/java/org/springframework/boot/autoconfigure/aerospike/AerospikeProperties.java#L205-L212